### PR TITLE
Wrong module name used in evaluateCompletion

### DIFF
--- a/src/Payment/Method/TPay.php
+++ b/src/Payment/Method/TPay.php
@@ -80,7 +80,7 @@ class TPay extends Component implements EvaluationInterface
 
     public function evaluateCompletion(EvaluationResultFactory $resultFactory): EvaluationResultInterface
     {
-        if ($this->sessionCheckout->getQuote()->getPayment()->getMethod() != 'tpaycom_magento2basic') {
+        if ($this->sessionCheckout->getQuote()->getPayment()->getMethod() != 'Tpay_Magento2') {
             return $resultFactory->createSuccess();
         }
 


### PR DESCRIPTION
The old module name is used for validating the payment method data, so it is immediately validated every time even if TOS is not checked nor a payment method is selected. So, there's a tiny fix for that. 😄 